### PR TITLE
chore(query): post-upgrade polish (#22)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { QueryClientProvider } from "@tanstack/react-query";
 import Toast from "react-native-toast-message";
 
+import { ReactQueryDevtoolsGate } from "./components/dev/ReactQueryDevtoolsGate";
 import { CustomerDetailsProvider } from "./context/CustomerDetailsContext";
 import { queryClient } from "./lib/queryClient";
 
@@ -49,6 +50,7 @@ export default function App() {
               <StatusBar />
               <Toast />
             </CustomerDetailsProvider>
+            <ReactQueryDevtoolsGate />
           </QueryClientProvider>
         </NativeBaseProvider>
       </SafeAreaProvider>

--- a/components/cards/CustomerCard.tsx
+++ b/components/cards/CustomerCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import { Button, Modal } from "native-base";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, memo, useEffect, useState } from "react";
 import {
   Pressable,
   StyleSheet,
@@ -20,12 +20,12 @@ interface CustomerCardProps {
   setIsDeleted: Dispatch<SetStateAction<boolean | null>>;
   isDeleted: boolean | null;
 }
-const CustomerCard = ({
+const CustomerCard = memo(function CustomerCard({
   customer,
   populateCustomersList,
   isDeleted,
   setIsDeleted,
-}: CustomerCardProps) => {
+}: CustomerCardProps) {
   const [showModal, setShowModal] = useState<boolean>(false);
 
   const { name, city } = customer;
@@ -113,7 +113,7 @@ const CustomerCard = ({
       />
     </>
   );
-};
+});
 
 const styles = StyleSheet.create({
   cardContainer: {

--- a/components/cards/OrderCard.tsx
+++ b/components/cards/OrderCard.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, memo, useState } from "react";
 
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
@@ -18,14 +18,14 @@ interface OrderCardProps {
   customerId: string | number;
 }
 
-const OrderCard = ({
+const OrderCard = memo(function OrderCard({
   client_name,
   data,
   isDeleted,
   setIsDeleted,
   populateData,
   customerId,
-}: OrderCardProps) => {
+}: OrderCardProps) {
   const navigation = useNavigation();
 
   const {
@@ -107,7 +107,7 @@ const OrderCard = ({
       </Pressable>
     </View>
   );
-};
+});
 
 const styles = StyleSheet.create({
   container: {

--- a/components/dev/ReactQueryDevtoolsGate.tsx
+++ b/components/dev/ReactQueryDevtoolsGate.tsx
@@ -1,0 +1,15 @@
+import { Platform } from "react-native";
+
+/**
+ * TanStack Devtools are DOM-based; keep them off native bundles and production.
+ * Only `expo start --web` + `__DEV__` loads the module.
+ */
+export function ReactQueryDevtoolsGate() {
+  if (!__DEV__ || Platform.OS !== "web") {
+    return null;
+  }
+  const {
+    ReactQueryDevtools,
+  } = require("@tanstack/react-query-devtools") as typeof import("@tanstack/react-query-devtools");
+  return <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />;
+}

--- a/hooks/useCustomersWithOrdersQuery.ts
+++ b/hooks/useCustomersWithOrdersQuery.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchCustomersWithOrders } from "../lib/customers/fetchCustomersWithOrders";
+import { QUERY_GC_MS, QUERY_STALE_MS } from "../lib/queryDefaults";
 import { customerKeys } from "../lib/queryKeys";
 
 export function useCustomersWithOrdersQuery() {
   return useQuery({
     queryKey: customerKeys.listWithOrders(),
     queryFn: fetchCustomersWithOrders,
-    staleTime: 60_000,
+    staleTime: QUERY_STALE_MS.listWithOrders,
+    gcTime: QUERY_GC_MS.listWithOrders,
   });
 }

--- a/lib/queryClient.ts
+++ b/lib/queryClient.ts
@@ -1,9 +1,19 @@
 import { QueryClient } from "@tanstack/react-query";
 
+import { QUERY_GC_MS, QUERY_STALE_MS } from "./queryDefaults";
+
+/**
+ * Global defaults: RN has no browser “window focus”; disabling avoids surprise
+ * refetches when the app resumes. Entity-specific `staleTime` / `gcTime` live in
+ * `queryDefaults.ts` and are mirrored here for queries that omit overrides.
+ */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 1,
+      staleTime: QUERY_STALE_MS.listWithOrders,
+      gcTime: QUERY_GC_MS.listWithOrders,
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/lib/queryDefaults.ts
+++ b/lib/queryDefaults.ts
@@ -1,0 +1,16 @@
+/**
+ * TanStack Query tuning for server-backed lists (see GitHub #22).
+ *
+ * - `listWithOrders` backs Customers, Orders, and Finance list UIs via
+ *   `useCustomersWithOrdersQuery` and `customerKeys.listWithOrders`.
+ * - Adjust here so all consumers stay aligned; override per-query only when a
+ *   screen needs tighter freshness.
+ */
+export const QUERY_STALE_MS = {
+  listWithOrders: 60_000,
+} as const;
+
+/** Time unused cached data stays in memory before garbage collection. */
+export const QUERY_GC_MS = {
+  listWithOrders: 5 * 60_000,
+} as const;

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,6 +1,12 @@
 /**
- * `listWithOrders` — HTTP GET `/api/customer` + `/api/orders`, merged for list UIs.
- * Orders tab and finance views derive rows from this key so a single invalidation refreshes all.
+ * Query key factories (TanStack Query v5).
+ *
+ * Invalidation strategy:
+ * - Customer create/update/delete and order mutations should target `customerKeys.all`
+ *   (or `listWithOrders` when you only need the merged list) so Customers, Orders, and
+ *   Finance stay in sync — they all read `useCustomersWithOrdersQuery`.
+ *
+ * Cache policy numbers live in `queryDefaults.ts` + `queryClient` defaults (#22).
  */
 export const customerKeys = {
   all: ["customers"] as const,

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-transform-private-methods": "^7.28.6",
     "@react-navigation/stack": "^6.3.20",
+    "@tanstack/react-query-devtools": "^5.100.10",
     "@types/jest": "29.5.14",
     "@types/react": "~19.2.10",
     "@types/react-navigation": "^3.4.0",

--- a/screens/CustomersScreen.tsx
+++ b/screens/CustomersScreen.tsx
@@ -50,9 +50,9 @@ const CustomersScreen = () => {
     }
   }, [error]);
 
-  const populateCustomersList = () => {
+  const populateCustomersList = useCallback(() => {
     void refetch();
-  };
+  }, [refetch]);
 
   const openModal = () => {
     setShowModal(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,6 +2707,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.100.10.tgz#aeb34d301fd4ff9762e67dfa018adc33b7a18be4"
   integrity sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==
 
+"@tanstack/query-devtools@5.100.10":
+  version "5.100.10"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.100.10.tgz#1972789fdc7c4cb9ec2062d51f25bc4dc655a27b"
+  integrity sha512-3DmJf25hDPus5IpVvp6ujXv6bKV2zPzI9vpbAmpJigsL/H6DPvPjmf7/Q9yVKEke//8fgeQ45abjgnLuyYxAiw==
+
+"@tanstack/react-query-devtools@^5.100.10":
+  version "5.100.10"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.100.10.tgz#cca3479cc2c8b434637c31f8119fe6ff93e5832c"
+  integrity sha512-zes0+o9ef5rAZXJ9f/SeaLs2nufJaeVkZkl/Or9NGrWVF41kL9Od9ED9nCwtQlgiF2VGtrzhEw5AU/igAO+aAg==
+  dependencies:
+    "@tanstack/query-devtools" "5.100.10"
+
 "@tanstack/react-query@^5.100.10":
   version "5.100.10"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.100.10.tgz#3bf1844efd76f5f68f9f39da2917fc4c6023e726"


### PR DESCRIPTION
## Summary

Implements GitHub #22: cache tuning, optional React Query Devtools (web + dev only), and lighter list renders.

## Changes

- `lib/queryDefaults.ts`: single source for `staleTime` / `gcTime` for the merged customers+orders list; documented in-file and cross-referenced from `queryKeys.ts`.
- `lib/queryClient.ts`: default `refetchOnWindowFocus: false` for React Native; align default query `staleTime` / `gcTime` with list policy.
- `useCustomersWithOrdersQuery`: uses shared constants (`gcTime` added).
- `ReactQueryDevtoolsGate`: `__DEV__` and `Platform.OS === "web"` only; native production bundles never load the devtools package.
- Customers screen: stable `populateCustomersList` via `useCallback`.
- `CustomerCard` / `OrderCard`: `React.memo` on named components.

## Checks

- `npx jest --ci --watchAll=false`

Closes #22.
